### PR TITLE
Changing log.fatal to log.panic

### DIFF
--- a/yahoo_weather_api.go
+++ b/yahoo_weather_api.go
@@ -16,6 +16,10 @@ const (
 	publicAPIURL string = "http://query.yahooapis.com/v1/public/yql"
 )
 
+func getPublicAPIURL() string{
+	return publicAPIURL
+}
+
 type ForecastInfo struct {
 	Code float64
 	Date string //time.Time
@@ -98,8 +102,7 @@ func BuildURL(query string) string {
 	params.Add("format", "json")
 	//	params.Add("diagnostics", "true")
 	params.Add("callback", "")
-
-	return publicAPIURL + "?" + params.Encode()
+	return getPublicAPIURL() + "?" + params.Encode()
 }
 
 // getJSON returns the JSON response
@@ -108,7 +111,8 @@ func getJSON(url string) []byte {
 	resp, errReq := http.Get(url)
 
 	if errReq != nil {
-		log.Fatalf("%s", errReq.Error())
+		log.Panicf("%s", errReq.Error())
+		return []byte("")
 	}
 
 	defer resp.Body.Close()

--- a/yahoo_weather_api_test.go
+++ b/yahoo_weather_api_test.go
@@ -1,6 +1,7 @@
 package yahoo
 
 import (
+	"bou.ke/monkey"
 	"fmt"
 	"testing"
 	"unsafe"
@@ -23,6 +24,27 @@ func TestYahooApiGetForecastData(t *testing.T) {
 			t.Fatalf("The forecast representing  is nil.\n")
 		}
 	}
+}
+
+func TestYahooApiGetWrongForecastData(t *testing.T) {
+	monkey.Patch(getPublicAPIURL, func() string {
+		return "http://wrong_url"
+	})
+
+	defer func(){
+		if r := recover(); r != nil {
+			monkey.UnpatchAll()
+			f, _ := GetForecastlData("jiangmen,guangdong,china")
+
+			if f == nil {
+				t.Fatal("forecast is nil\n")
+			}
+
+		}
+	}()
+
+	GetForecastlData("jiangmen,guangdong,china")
+	t.Fatal("No panic")
 }
 
 func TestYahooApi_(t *testing.T) {


### PR DESCRIPTION
Greetings, 

Thank you for the cool library. I have small suggestion: if there's an error while retrieving data it's better to use panic, so it can be recovered. Right now os.Exit is called which is not very convenient.

To run monkey-pathing test you need to run with `-gcflags=-l`